### PR TITLE
feat: Add a localized name for create_db_thread

### DIFF
--- a/src/commands/create_db_thread.rs
+++ b/src/commands/create_db_thread.rs
@@ -60,5 +60,7 @@ pub async fn run(
 pub fn register(command: &mut CreateApplicationCommand) -> &mut CreateApplicationCommand {
     command
         .name("create_db_thread")
+        .name_localized("en-US", "Create a DB Thread")
+        .name_localized("en-GB", "Create a DB Thread")
         .kind(serenity::model::prelude::command::CommandType::Message)
 }


### PR DESCRIPTION
Just something nicer to look at than `create_db_thread`.